### PR TITLE
Bot will respond with custom keyboards

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,29 +75,17 @@ Found 5 movies:
 3) Ernest Goes to Africa - 1997 - 4.7/10 - 90m
 4) Ernest Goes to School - 1994 - 4.5/10 - 89m
 5) Ernest Goes to Splash Mountain - 1989 - 6.7/10 - 21m
-
-/m [number] to continue...
 ```
 
-Send the number of the movie you want with the /m flag
+Use the custom keyboard to select the movie.
+
+The bot will then ask you for the quality
 
 ```
-/m 1
+A) SD B) HD C) Screener D) R5 E) DVD-Rip F) BR-Rip G) 720p H) 1080p I) BR-Disk J) DVD-R K) TeleCine L) TeleSync M) Cam
 ```
 
-Finally the bot will ask you for the quality
-
-```
-1) SD 2) HD 3) Screener 4) R5 5) DVD-Rip 6) BR-Rip 7) 720p 8) 1080p 9) BR-Disk 10) DVD-R 11) TeleCine 12) TeleSync 13) Cam
-
-/p [number] to continue...
-```
-
-Send the number of the profile
-
-```
-/p 1
-```
+Send the profile using the custom keyboard
 
 If everything goes well, you'll see a text from the bot saying the movie was added.
 

--- a/couchpotato.js
+++ b/couchpotato.js
@@ -5,6 +5,13 @@ var TelegramBot = require('node-telegram-bot-api');
 var NodeCache = require('node-cache');
 var _ = require('lodash');
 
+class Response {
+    constructor(message, keyboard) {
+      this.message = message;
+      this.keyboard = keyboard;
+    }
+}
+
 try {
   var config = require('./config.json');
 } catch (e) {
@@ -80,7 +87,8 @@ bot.onText(/\/[Qq](uery)? (.+)/, function(msg, match) {
       console.log(fromId + ' requested to search for movie ' + movieName);
 
       var movieList = [];
-      var response = ['*Found ' + movies.length + ' movies:*'];
+      var message = ['*Found ' + movies.length + ' movies:*'];
+      var keyboardList = [];
 
       _.forEach(movies, function(n, key) {
 
@@ -92,6 +100,7 @@ bot.onText(/\/[Qq](uery)? (.+)/, function(msg, match) {
         var thumb = ('images' in n ? ('poster' in n.images ? n.images.poster[0] : '') : '');
         var runtime = ('runtime' in n ? n.runtime : '');
         var onIMDb = ('via_imdb' in n ? true : false);
+        var keyboardValue = id + ") " + title + (year ? ' - ' + year : '')
 
         movieList.push({
           'id': id,
@@ -100,47 +109,56 @@ bot.onText(/\/[Qq](uery)? (.+)/, function(msg, match) {
           'rating': rating,
           'movie_id': movieId,
           'thumb': thumb,
-          'via_imdb': onIMDb
+          'via_imdb': onIMDb,
+          'keyboard_value': keyboardValue
         });
 
-        response.push(
+        message.push(
           '*' + id + '*) ' +
           (onIMDb ? '[' + title + '](http://imdb.com/title/' + movieId + ')' : '[' + title + '](https://www.themoviedb.org/movie/' + movieId + ')') +
           (year ? ' - _' + year + '_' : '') +
           (rating ? ' - _' + rating + '_' : '') +
           (runtime ? ' - _' + runtime + 'm_' : '')
         );
-      });
 
-      response.push('\n`/m [n]` to continue...');
+        keyboardList.push(
+          // One movie per row of custom keyboard
+          [keyboardValue]
+        )
+      });
 
       // set cache
       cache.set('movieList' + fromId, movieList);
 
-      return response.join('\n');
+      return new Response(message.join('\n'), keyboardList);
     })
     .then(function(response) {
       var opts = {
         'disable_web_page_preview': true,
         'parse_mode': 'Markdown',
         'selective': 2,
+        'reply_markup': {
+          'keyboard': response.keyboard,
+          'one_time_keyboard': true
+        }
       };
 
-      bot.sendMessage(chatId, response, opts);
+      bot.sendMessage(chatId, response.message, opts);
     })
     .catch(function(err) {
-      bot.sendMessage(chatId, 'Oh no! ' + err);
+      replyWithError(chatId, err)
     });
 
 });
 
 /*
 handle movie command
+in the form "1) Die Hard -- 1988", "2) Die Hard 2 -- 1990", etc.
  */
-bot.onText(/\/[mM](ovie)? ([\d]+)/, function(msg, match) {
+bot.onText(/([\d]+)\) .*/, function(msg, match) {
   var chatId = msg.chat.id;
   var fromId = msg.from.id;
-  var movieId = match[2];
+  var movieId = match[1].replace(')', '');
 
   // set movie option to cache
   cache.set('movieId' + fromId, movieId);
@@ -161,6 +179,8 @@ bot.onText(/\/[mM](ovie)? ([\d]+)/, function(msg, match) {
       console.log(fromId + ' requested to get profiles list');
 
       var profileList = [];
+      var keyboardList = [];
+      var keyboardRow = [];
       var response = ['*Found ' + profiles.length + ' profiles:*\n'];
       _.forEach(profiles, function(n, key) {
         profileList.push({
@@ -168,41 +188,54 @@ bot.onText(/\/[mM](ovie)? ([\d]+)/, function(msg, match) {
           'label': n.label,
           'hash': n._id
         });
+        // Keep profile id as an integer, convert to char for display
+        var keyAsChar = String.fromCharCode("A".charCodeAt(0) + key);
 
-        response.push('*' + (key + 1) + '*) ' + n.label);
+        response.push('*' + keyAsChar + '*) ' + n.label);
+
+        // Profile names are short, put two on each custom
+        // keyboard row to reduce scrolling
+        keyboardRow.push(keyAsChar + ") " + n.label);
+        if (keyboardRow.length == 2) {
+          keyboardList.push(keyboardRow);
+          keyboardRow = [];
+        }
       });
-
-      response.push('\n\n`/p [n]` to continue...');
 
       // set cache
       cache.set('movieProfileList' + fromId, profileList);
 
-      return response.join(' ');
+      return new Response(response.join(' '), keyboardList);
     })
     .then(function(response) {
-      bot.sendMessage(chatId, response, {
+      bot.sendMessage(chatId, response.message, {
         'selective': 2,
-        'parse_mode': 'Markdown'
+        'parse_mode': 'Markdown',
+        'reply_markup': {
+          'keyboard': response.keyboard,
+          'one_time_keyboard': true
+        }
       });
     })
     .catch(function(err) {
-      bot.sendMessage(chatId, 'Oh no! ' + err);
+      replyWithError(chatId, err)
     });
 });
 
 /*
 handle quality profile command
+in the form "A) HD", "B) SD", etc.
  */
-bot.onText(/\/[pP](rofile)? ([\d]+)/, function(msg, match) {
+bot.onText(/([A-Z])\) .*/, function(msg, match) {
   var chatId = msg.chat.id;
   var fromId = msg.from.id;
-  var profileId = match[2];
+  var profileId = match[1].replace(')', '').charCodeAt(0) - "A".charCodeAt(0) + 1;
   var profileList = cache.get('movieProfileList' + fromId);
   var movieId = cache.get('movieId' + fromId);
   var movieList = cache.get('movieList' + fromId);
 
   if (profileList === undefined || movieList === undefined || movieId === undefined) {
-    bot.sendMessage(chatId, 'Oh no! Error: something went wrong, try searching again');
+    throw new Error('Error: something went wrong, try searching again')
   }
 
   var movie = _.filter(movieList, function(item) {
@@ -228,11 +261,14 @@ bot.onText(/\/[pP](rofile)? ([\d]+)/, function(msg, match) {
 
       bot.sendMessage(chatId, '[Movie added!](' + movie.thumb + ')', {
         'selective': 2,
-        'parse_mode': 'Markdown'
+        'parse_mode': 'Markdown',
+        'reply_markup': {
+          'hide_keyboard': true
+        }
       });
     })
     .catch(function(err) {
-      bot.sendMessage(chatId, 'Oh no! ' + err);
+      replyWithError(chatId, err);
     })
     .finally(function() {
 
@@ -254,7 +290,7 @@ bot.onText(/\/searchwanted/, function(msg) {
     .then(function(result) {
       bot.sendMessage(chatId, 'Starting full search for all wanted movies.');
     }).catch(function(err) {
-      bot.sendMessage(chatId, 'Oh no! ' + err);
+      replyWithError(chatId, err);
     });
 });
 
@@ -271,3 +307,14 @@ bot.onText(/\/clear/, function(msg) {
 
   bot.sendMessage(chatId, 'All previously sent commands have been cleared, yey!');
 });
+
+/*
+ * Shared err message logic, primarily to handle removing the custom keyboard
+ */
+function replyWithError(chatId, err) {
+  bot.sendMessage(chatId, 'Oh no! ' + err, {  
+    'reply_markup': {
+      'hide_keyboard': true
+    }
+  });
+}

--- a/couchpotato.js
+++ b/couchpotato.js
@@ -305,7 +305,11 @@ bot.onText(/\/clear/, function(msg) {
   cache.del('movieId' + fromId);
   cache.del('movieProfileList' + fromId);
 
-  bot.sendMessage(chatId, 'All previously sent commands have been cleared, yey!');
+  bot.sendMessage(chatId, 'All previously sent commands have been cleared, yey!', {
+    'reply_markup': {
+      'hide_keyboard': true
+    }
+  });
 });
 
 /*


### PR DESCRIPTION
Expand the telegram-couchpotato-bot to take advantage of the Telegram bot [custom keyboards](https://core.telegram.org/bots#keyboards).
* Add custom keyboard to response
* Change regex for movie and profile handling
* Add `replyWithError` function

**What motivated this change?**
My primary use case for the Telegram CouchPotato Bot is adding movies on the go. The existing command structure is very terse, but requires more typing than I want to do for a task like this on a phone.

**What was the solution?**
Use the custom keyboards functionality of the Telegram Bot API. As we build up the response body, also construct an array to be sent as the keyboard options.

**What is the impact of this change?**
Less typing is involved in adding a new movie. The regex expression the the bot looks for has changed to accommodate the custom keyboard. Changing to `1) Movie Name` and `A) Profile` made the keyboard options cleaner and allowed the bulk of the bot logic to remain the same.

If it is desirable for the `/m [n]` and `/p [n]` commands to stay some refactoring could be done to pull movie and profile logic out into their own functions, to be called on both `/m 1` and `1) movie name` regex expressions.

**Show me how this custom keyboard looks**
Desktop Client (OSX)
<img width="400" alt="desktop client select movie" src="https://cloud.githubusercontent.com/assets/1662279/12041253/e5123f66-ae2c-11e5-88ca-7723706bd1f6.png">
<img width="400" alt="desktop client select profile" src="https://cloud.githubusercontent.com/assets/1662279/12041260/f912e560-ae2c-11e5-9fc4-cfd53a5d1353.png">

Mobile Client (iOS)
![2015-12-29 12 58 06](https://cloud.githubusercontent.com/assets/1662279/12041324/7c3d227a-ae2d-11e5-8a73-58fb30b19e32.png)
![2015-12-29 12 58 13](https://cloud.githubusercontent.com/assets/1662279/12041332/8f5212da-ae2d-11e5-843e-6346f1343d3a.png)